### PR TITLE
Add support for version 231

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@
 
 pluginGroup = com.github.lunakoly.quicklink
 pluginName=Quick Link
-pluginVersion=1.0.5
+pluginVersion=1.0.6
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=211
-pluginUntilBuild=223.*
+pluginUntilBuild=231.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2021.1.1, 2021.2, 2021.3, 2022.1, 2022.2, 2022.3
+pluginVerifierIdeVersions=2021.1.1, 2021.2, 2021.3, 2022.1, 2022.2, 2022.3, 2023.1
 
 platformType = IC
 platformVersion = 2021.1.3


### PR DESCRIPTION
add support for intellij 2023.1 version. 211 is not removed from the support matrix since it is still being actively used as per statistics given here https://plugins.jetbrains.com/docs/marketplace/product-versions-in-use-statistics.html