### PR TITLE
🛠️ Fix compiling and multiline selection issue for IDE 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixed multiline selection on IDE version 2024
+- Fixed compiling on IDE version 2024
+
 ## [1.0.8] - 2024-05-11
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.lunakoly.quicklink
 pluginName = Quick Link
 pluginRepositoryUrl = https://github.com/lunakoly/QuickLink
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.8
+pluginVersion = 1.0.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 211

--- a/src/main/kotlin/org/lunakoly/quicklink/actions/CopyLineLinkAction.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/actions/CopyLineLinkAction.kt
@@ -53,8 +53,8 @@ class CopyLineLinkAction : DumbAwareAction() {
             ?: throw NoActiveFileException()
 
         val selection = if (editor.selectionModel.hasSelection()) {
-            val startLine = 1 + editor.selectionModel.selectionStartPosition!!.getLine()
-            val endLine = 1 + editor.selectionModel.selectionEndPosition!!.getLine()
+            val startLine = 1 + editor.document.getLineNumber(editor.selectionModel.selectionStart)
+            val endLine = 1 + editor.document.getLineNumber(editor.selectionModel.selectionEnd)
             val startColumn = 1 + editor.selectionModel.selectionStartPosition!!.getColumn()
             val endColumn = 1 + editor.selectionModel.selectionEndPosition!!.getColumn()
             val startOffset = LineOffset(startLine, startColumn)

--- a/src/main/kotlin/org/lunakoly/quicklink/settings/QuickLinkSettingsComponent.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/settings/QuickLinkSettingsComponent.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.actionSystem.ActionToolbarPosition
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.table.JBTable
-import com.intellij.util.castSafelyTo
 import java.awt.Color
 import javax.swing.table.JTableHeader
 
@@ -68,13 +67,13 @@ class QuickLinkSettingsComponent {
     }
 
     private fun onApply() {
-        tableDomains.model.castSafelyTo<DomainToServiceTableModel>()?.addEmptyRow()
+        (tableDomains.model as? DomainToServiceTableModel)?.addEmptyRow()
         tableDomains.updateUI()
     }
 
     private fun onDelete(rowIndex: Int?) {
         if (rowIndex != null) {
-            tableDomains.model.castSafelyTo<DomainToServiceTableModel>()?.deleteRow(rowIndex)
+            (tableDomains.model as? DomainToServiceTableModel)?.deleteRow(rowIndex)
         }
         tableDomains.updateUI()
     }

--- a/src/main/kotlin/org/lunakoly/quicklink/ui/Helpers.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/ui/Helpers.kt
@@ -37,13 +37,17 @@ const val FADE_OUT_DELAY_MS = 3000L
 
 fun Project.toast(message: String) {
     val statusBar = WindowManager.getInstance().getStatusBar(this)
+    val component = statusBar.component ?: run {
+        println("statusBar component is null")
+        return
+    }
 
     JBPopupFactory.getInstance()
         .createHtmlTextBalloonBuilder(message, MessageType.INFO, null)
         .setFadeoutTime(FADE_OUT_DELAY_MS)
         .createBalloon()
         .show(
-            RelativePoint.getCenterOf(statusBar.component),
+            RelativePoint.getCenterOf(component),
             Balloon.Position.atRight
         )
 }


### PR DESCRIPTION
- fix multiline selection in newer IDE versions (2024)
- fix compiling on newer IDE (2024)



NOTES TO REVIEWER:
I have tested the multiline selection on IC 2021.1, IC 2024.1.2 and GO 2024.1.2.  So not exactly sure which version of IDE broke the compatibility. The compiling was also tried on the above mentioned versions. 