### PR TITLE
Unlock line link for modified files & introduce smarter commit picking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           git config user.name "GitHub Action"
 
           git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
+          git commit -am "📃 Changelog update - $VERSION"
           git push --set-upstream origin $BRANCH
           
           gh label create "$LABEL" \
@@ -94,7 +94,7 @@ jobs:
             || true
 
           gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
+            --title "📃 Changelog update - \`$VERSION\`" \
             --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
             --label "$LABEL" \
             --head $BRANCH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Now the plugin allows generating links to modified files, even though the lines may be inaccurate
+
 ## [1.0.10] - 2024-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 - Now the plugin allows generating links to modified files, even though the lines may be inaccurate
+- If the current commit is not reachable from remote branches, the plugin will look for the closest parent commit that is
+
+### Added
+- Two new actions: "Copy Current Commit Line Link" (the old behavior) and "Copy Latest Default Line Link"
 
 ## [1.0.10] - 2024-06-29
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ The newly generated link will be copied to your clipboard automatically.
 Use the `Settings > Tools > Quick Link` tab to configure custom domain mappings.
 It allows associating corporate domains with the corresponding service providers
 (link generation would be done in the same way as it's done for the official 
-github.com/gitlab.com/... domains)
+github.com/gitlab.com/... domains).
+
+Additionally, use `Copy Current Commit Line Link` and `Copy Latest Default Line Link` to obtain
+links to exactly the currently checked-out commit or the latest locally known commit of the remote's default branch.
+The default action is designed to get "some close" link as the main use case is to quickly refer to a place in code:
+if the current commit has not been pushed to the remote, we're looking for a parent commit that has been (by considering
+common parents between the current commit and either the currently tracked remote branch or the remote's default branch). 
 
 ![Settings Tab Image](https://drive.google.com/uc?export=download&id=1qIt8gfIkYNIt8qfIrSP-jl3lrhzvgYMp)
 
-The extension can currently generate links to remotes powered by GitHub, GitLab and Bitbucket services.
-
-Unfortunately, the extension:
-
-1. can not generate links to locally modified files (even if these modifications take place after the current cursor location).
+The extension can currently generate links to remotes powered by GitHub, GitLab, Space and Bitbucket services.
 
 ---
 Plugin based on the [IntelliJ Platform Plugin Template][template].

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.lunakoly.quicklink
 pluginName = Quick Link
 pluginRepositoryUrl = https://github.com/lunakoly/QuickLink
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.10
+pluginVersion = 1.0.11
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 211

--- a/src/main/kotlin/org/lunakoly/quicklink/actions/CopyLineLinkAction.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/actions/CopyLineLinkAction.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.VfsUtilCore
 import org.lunakoly.quicklink.repository.getRepositoryInfo
+import org.lunakoly.quicklink.ui.warn
 import org.lunakoly.quicklink.ui.showClickableListIfNeeded
 import org.lunakoly.quicklink.ui.toast
 import org.lunakoly.quicklink.urlbuilder.LineOffset
@@ -35,11 +36,6 @@ class NoActiveFileException : PopupException(
 class RelativePathException : PopupException(
     "Could not calculate the relative file path",
     "No Relative Path",
-)
-
-class ModifiedFileException : PopupException(
-    "Locally modified files do not have a remote representation",
-    "Modified File",
 )
 
 class CopyLineLinkAction : DumbAwareAction() {
@@ -76,7 +72,7 @@ class CopyLineLinkAction : DumbAwareAction() {
             .getChange(currentFile) != null
 
         if (currentFileIsModified) {
-            throw ModifiedFileException()
+            project.warn("This is a locally modified file, the line number may be inaccurate")
         }
 
         editor.showClickableListIfNeeded(

--- a/src/main/kotlin/org/lunakoly/quicklink/actions/CopyLineLinkAction.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/actions/CopyLineLinkAction.kt
@@ -4,19 +4,48 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.VfsUtilCore
-import org.lunakoly.quicklink.repository.getRepositoryInfo
-import org.lunakoly.quicklink.ui.warn
+import git4idea.repo.GitRepository
+import org.lunakoly.quicklink.repository.*
 import org.lunakoly.quicklink.ui.showClickableListIfNeeded
 import org.lunakoly.quicklink.ui.toast
+import org.lunakoly.quicklink.ui.warn
 import org.lunakoly.quicklink.urlbuilder.LineOffset
 import org.lunakoly.quicklink.urlbuilder.Selection
 import org.lunakoly.quicklink.urlbuilder.UrlBuilders
 import org.lunakoly.quicklink.utils.PopupException
 import org.lunakoly.quicklink.utils.catchingPopupExceptions
+import org.lunakoly.quicklink.utils.runInBackground
 import org.lunakoly.quicklink.utils.toDomain
 import java.awt.datatransfer.StringSelection
+
+class CopyLineLinkAction : DumbAwareAction() {
+    override fun actionPerformed(event: AnActionEvent) {
+        catchingPopupExceptions {
+            generateLineLink(event, ::getReasonablePublishedRepositoryInfo)
+        }
+    }
+}
+
+class CopyCurrentCommitLineLinkAction : DumbAwareAction() {
+    override fun actionPerformed(event: AnActionEvent) {
+        catchingPopupExceptions {
+            generateLineLink(event) { repo, _, _ ->
+                getCurrentCommitRepositoryInfo(repo)
+            }
+        }
+    }
+}
+
+class CopyLatestDefaultLineLinkAction : DumbAwareAction() {
+    override fun actionPerformed(event: AnActionEvent) {
+        catchingPopupExceptions {
+            generateLineLink(event, ::getLatestDefaultRepositoryInfo)
+        }
+    }
+}
 
 class NoProjectException : PopupException(
     "Please, open a project",
@@ -38,61 +67,57 @@ class RelativePathException : PopupException(
     "No Relative Path",
 )
 
-class CopyLineLinkAction : DumbAwareAction() {
-    @Suppress("ThrowsCount")
-    private fun generateLineLink(event: AnActionEvent) {
-        val project = event.project
-            ?: throw NoProjectException()
-        val editor = event.getData(CommonDataKeys.EDITOR)
-            ?: throw NoEditorException()
-        val currentFile = event.dataContext.getData(CommonDataKeys.VIRTUAL_FILE)?.canonicalFile
-            ?: throw NoActiveFileException()
+private inline fun generateLineLink(
+    event: AnActionEvent,
+    crossinline getInfo: (GitRepository, Project, String) -> RepositoryInfo,
+) {
+    val project = event.project
+        ?: throw NoProjectException()
+    val editor = event.getData(CommonDataKeys.EDITOR)
+        ?: throw NoEditorException()
+    val currentFile = event.dataContext.getData(CommonDataKeys.VIRTUAL_FILE)?.canonicalFile
+        ?: throw NoActiveFileException()
 
-        val selection = if (editor.selectionModel.hasSelection()) {
-            val startLine = 1 + editor.document.getLineNumber(editor.selectionModel.selectionStart)
-            val endLine = 1 + editor.document.getLineNumber(editor.selectionModel.selectionEnd)
-            val startColumn = 1 + editor.selectionModel.selectionStartPosition!!.getColumn()
-            val endColumn = 1 + editor.selectionModel.selectionEndPosition!!.getColumn()
-            val startOffset = LineOffset(startLine, startColumn)
-            val endOffset = LineOffset(endLine, endColumn)
-            Selection.MultilineSelection(startOffset, endOffset)
-        } else {
-            val lineOffset = LineOffset(1 + editor.document.getLineNumber(editor.caretModel.offset), 0)
-            Selection.SingleLinkSelection(lineOffset)
-        }
+    val currentFileIsModified = ChangeListManager
+        .getInstance(project)
+        .getChange(currentFile) != null
 
-        val repositoryInfo = getRepositoryInfo(project, currentFile)
+    if (currentFileIsModified) {
+        project.warn("This is a locally modified file, the line number may be inaccurate")
+    }
 
-        val filePath = VfsUtilCore
-            .findRelativePath(repositoryInfo.root, currentFile, VfsUtilCore.VFS_SEPARATOR_CHAR)
-            ?: throw RelativePathException()
+    val selection = if (editor.selectionModel.hasSelection()) {
+        val startLine = 1 + editor.document.getLineNumber(editor.selectionModel.selectionStart)
+        val endLine = 1 + editor.document.getLineNumber(editor.selectionModel.selectionEnd)
+        val startColumn = 1 + editor.selectionModel.selectionStartPosition!!.getColumn()
+        val endColumn = 1 + editor.selectionModel.selectionEndPosition!!.getColumn()
+        val startOffset = LineOffset(startLine, startColumn)
+        val endOffset = LineOffset(endLine, endColumn)
+        Selection.MultilineSelection(startOffset, endOffset)
+    } else {
+        val lineOffset = LineOffset(1 + editor.document.getLineNumber(editor.caretModel.offset), 0)
+        Selection.SingleLinkSelection(lineOffset)
+    }
 
-        val currentFileIsModified = ChangeListManager
-            .getInstance(project)
-            .getChange(currentFile) != null
+    val repository = getRepositoryFor(currentFile, project)
+    val remotesMap = repository.getRemotesMap()
 
-        if (currentFileIsModified) {
-            project.warn("This is a locally modified file, the line number may be inaccurate")
-        }
+    editor.showClickableListIfNeeded(things = remotesMap.keys.toList(), title = "Select a Remote") { remote ->
+        project.runInBackground("Generating the line link") {
+            val repositoryInfo = getInfo(repository, project, remote)
 
-        editor.showClickableListIfNeeded(
-            repositoryInfo.remotesNames,
-            title = "Select a Remote",
-        ) {
-            val remoteLink = repositoryInfo.remotes[it]
-                ?: return@showClickableListIfNeeded
+            val filePath = VfsUtilCore
+                .findRelativePath(repositoryInfo.root, currentFile, VfsUtilCore.VFS_SEPARATOR_CHAR)
+                ?: throw RelativePathException()
+
+            val remoteLink = remotesMap[remote]
+                ?: return@runInBackground
 
             val urlBuilder = UrlBuilders.fromDomain(remoteLink.toDomain())
             val url = urlBuilder.buildUrl(remoteLink, repositoryInfo, filePath, selection)
 
             CopyPasteManager.getInstance().setContents(StringSelection(url))
             project.toast("Line link copied: $url")
-        }
-    }
-
-    override fun actionPerformed(event: AnActionEvent) {
-        catchingPopupExceptions {
-            generateLineLink(event)
         }
     }
 }

--- a/src/main/kotlin/org/lunakoly/quicklink/repository/RepositoryInfo.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/repository/RepositoryInfo.kt
@@ -7,7 +7,4 @@ class RepositoryInfo(
     @Suppress("unused")
     val branch: String?,
     val commitHash: String,
-    val remotes: Map<String, String>,
-) {
-    val remotesNames get() = remotes.keys.toList()
-}
+)

--- a/src/main/kotlin/org/lunakoly/quicklink/repository/RepositoryInfoBuilders.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/repository/RepositoryInfoBuilders.kt
@@ -1,10 +1,15 @@
 package org.lunakoly.quicklink.repository
 
-import org.lunakoly.quicklink.utils.PopupException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import git4idea.config.GitExecutableManager
+import git4idea.history.GitHistoryUtils
 import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryManager
+import org.lunakoly.quicklink.ui.warn
+import org.lunakoly.quicklink.utils.PopupException
 
 class InvalidRemotesException : PopupException(
     "No valid remotes found",
@@ -21,10 +26,45 @@ class GitRepositoryNeededException : PopupException(
     "No Git Repository Found",
 )
 
-fun getRepositoryInfoAsGit(repo: GitRepository): RepositoryInfo {
+fun getCurrentCommitRepositoryInfo(repo: GitRepository): RepositoryInfo =
+    getRepositoryInfo(repo) { repo.currentRevision }
+
+fun getLatestDefaultRepositoryInfo(repo: GitRepository, project: Project, remote: String): RepositoryInfo =
+    getRepositoryInfo(repo) {
+        val defaultBranch = detectDefaultBranchFor(remote, repo, project)
+        GitHistoryUtils.collectTimedCommits(project, repo.root, "$remote/$defaultBranch").firstOrNull()?.id?.asString()
+    }
+
+fun getReasonablePublishedRepositoryInfo(repo: GitRepository, project: Project, remote: String): RepositoryInfo =
+    getRepositoryInfo(repo) {
+        val remoteBranch = repo.currentBranch?.findTrackedBranch(repo)?.takeIf { it.remote.name == remote }
+        val commitHash = repo.currentRevision ?: throw NoRevisionException()
+
+        val publishedCommit = when {
+            remoteBranch != null -> GitHistoryUtils.getMergeBase(project, repo.root, remoteBranch.name, commitHash)?.rev
+            else -> findClosestDefaultBranchCommitTo(commitHash, repo, project, remote)
+        }
+
+        if (publishedCommit != commitHash) {
+            val commits = GitHistoryUtils.collectCommitsMetadata(project, repo.root, commitHash, publishedCommit)
+            val current = commits?.first()?.subject?.let { " (${commitHash.take(8)} \"$it\")" } ?: ""
+            val published = commits?.last()?.subject?.let { " (${publishedCommit?.take(8)} \"$it\")" } ?: ""
+            project.warn("The current commit$current is not available at the remote, picking the closest parent instead$published")
+        }
+
+        publishedCommit
+    }
+
+fun getRepositoryInfo(repo: GitRepository, getCommitHash: () -> String?): RepositoryInfo {
+    val branch = repo.currentBranch?.name
+    val commitHash = getCommitHash() ?: throw NoRevisionException()
+    return RepositoryInfo(repo.root, branch, commitHash)
+}
+
+fun GitRepository.getRemotesMap(): Map<String, String> {
     val map = mutableMapOf<String, String>()
 
-    repo.remotes.forEach {
+    remotes.forEach {
         val url = it.firstUrl
         val name = it.name
 
@@ -37,20 +77,43 @@ fun getRepositoryInfoAsGit(repo: GitRepository): RepositoryInfo {
         throw InvalidRemotesException()
     }
 
-    val branch = repo.currentBranch?.name
-
-    val commitHash = repo.currentRevision
-        ?: throw NoRevisionException()
-
-    return RepositoryInfo(repo.root, branch, commitHash, map)
+    return map
 }
 
-fun getRepositoryInfo(project: Project, file: VirtualFile): RepositoryInfo {
+fun findClosestDefaultBranchCommitTo(commitHash: String, repo: GitRepository, project: Project, remote: String): String {
+    val git = GitExecutableManager.getInstance().getExecutable(project)
+
+    val isPresentOnRemote = listOf(git.exePath, "branch", "-r", "--contains", commitHash)
+        .let(::GeneralCommandLine).withWorkDirectory(repo.root.path)
+        .let(::CapturingProcessHandler).runProcess()
+        .stdout.split("\n").any { it.startsWith("$remote/") }
+
+    if (isPresentOnRemote) {
+        return commitHash
+    }
+
+    val defaultBranch = detectDefaultBranchFor(remote, repo, project)
+    val branch = repo.branches.findRemoteBranch("$remote/$defaultBranch")
+        ?: return commitHash
+
+    return GitHistoryUtils.getMergeBase(project, repo.root, branch.name, commitHash)?.rev ?: commitHash
+}
+
+private fun detectDefaultBranchFor(remote: String, repo: GitRepository, project: Project): String {
+    val git = GitExecutableManager.getInstance().getExecutable(project)
+
+    return listOf(git.exePath, "symbolic-ref", "refs/remotes/origin/HEAD")
+        .let(::GeneralCommandLine).withWorkDirectory(repo.root.path)
+        .let(::CapturingProcessHandler).runProcess()
+        .stdout.trim().removePrefix("refs/remotes/$remote/")
+}
+
+fun getRepositoryFor(file: VirtualFile, project: Project): GitRepository {
     // a project can have multiple repositories reported, if there are
     // submodules in it. info about each of those repositories will be
     // fetched and returned
-    val repositories = GitRepositoryManager.getInstance(project)
-        .repositories.map { getRepositoryInfoAsGit(it) }
+    val repositories = GitRepositoryManager.getInstance(project).repositories
+
     if (repositories.isEmpty()) {
         throw GitRepositoryNeededException()
     }

--- a/src/main/kotlin/org/lunakoly/quicklink/ui/Helpers.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/ui/Helpers.kt
@@ -1,6 +1,7 @@
 package org.lunakoly.quicklink.ui
 
-import org.lunakoly.quicklink.ui.components.PopupExceptionsList
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageType
@@ -8,6 +9,7 @@ import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.awt.RelativePoint
+import org.lunakoly.quicklink.ui.components.PopupExceptionsList
 
 fun Editor.showClickableListOf(
     things: List<String>,
@@ -51,3 +53,9 @@ fun Project.toast(message: String) {
             Balloon.Position.atRight
         )
 }
+
+fun Project.warn(message: String) =
+    NotificationGroupManager.getInstance()
+        .getNotificationGroup("QuickLink Notifications")
+        .createNotification(message, NotificationType.WARNING)
+        .notify(this)

--- a/src/main/kotlin/org/lunakoly/quicklink/urlbuilder/UrlBuilders.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/urlbuilder/UrlBuilders.kt
@@ -8,8 +8,8 @@ import org.lunakoly.quicklink.urlbuilder.implementations.BitbucketUrlBuilder
 import org.lunakoly.quicklink.utils.PopupException
 
 class UnsupportedUrlFormatException(domain: String) : PopupException(
-    "Only Github / Gitlab / Bitbucket URLs are supported. The selected remote link domain is: '$domain'.",
-    "Non-{Github/Gitlab/Bitbucket} URL"
+    "Only ${UrlBuilders.nameVariants} URLs are supported. The selected remote link domain is: '$domain'.",
+    "Non-${UrlBuilders.nameVariants} URL"
 )
 
 private val namesMapping by lazy {
@@ -43,5 +43,7 @@ enum class UrlBuilders(
 
             return defaultDomainsMapping[domain] ?: throw UnsupportedUrlFormatException(domain)
         }
+
+        val nameVariants: String get() = values().joinToString("/") { it.name }
     }
 }

--- a/src/main/kotlin/org/lunakoly/quicklink/utils/ThreadingHelpers.kt
+++ b/src/main/kotlin/org/lunakoly/quicklink/utils/ThreadingHelpers.kt
@@ -1,0 +1,11 @@
+package org.lunakoly.quicklink.utils
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.ThrowableComputable
+
+fun Project?.runInBackground(progressTitle: String, block: () -> Unit) {
+    ProgressManager.getInstance().runProcessWithProgressSynchronously(
+        ThrowableComputable(block), progressTitle, true, this,
+    )
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,12 +23,28 @@
     <actions>
         <action id="org.lunakoly.quicklink.actions.CopyLineLinkAction"
                 class="org.lunakoly.quicklink.actions.CopyLineLinkAction" text="Copy Line Link"
-                description="Generates an URL link to the current line with respect to the selected git remote">
+                description="Generates an URL link to the current line at some reasonably close commit with respect to the selected git remote. 'Reasonably close' means the current commit if it has been pushed to the remote, the closest parent commit with the remote branch that has been pushed or the closest parent with the remote default branch if no remote branch available.">
             <add-to-group group-id="CopyFileReference" anchor="first"/>
             <keyboard-shortcut keymap="$default" first-keystroke="shift control L"/>
             <synonym text="Create Line Link"/>
             <synonym text="Generate Line Link"/>
             <synonym text="Link Line"/>
+        </action>
+        <action id="org.lunakoly.quicklink.actions.CopyCurrentCommitLineLinkAction"
+                class="org.lunakoly.quicklink.actions.CopyCurrentCommitLineLinkAction" text="Copy Current Commit Line Link"
+                description="Generates an URL link to the current line at the currently checked out commit with respect to the selected git remote">
+            <add-to-group group-id="CopyFileReference" anchor="first"/>
+            <synonym text="Create Current Line Link"/>
+            <synonym text="Generate Current Line Link"/>
+            <synonym text="Exact Current Line"/>
+        </action>
+        <action id="org.lunakoly.quicklink.actions.CopyLatestDefaultLineLinkAction"
+                class="org.lunakoly.quicklink.actions.CopyLatestDefaultLineLinkAction" text="Copy Latest Default Line Link"
+                description="Generates an URL link to the current line at the latest default branch commit with respect to the selected git remote">
+            <add-to-group group-id="CopyFileReference" anchor="first"/>
+            <synonym text="Create Latest Default Line Link"/>
+            <synonym text="Generate Latest Default Line Link"/>
+            <synonym text="Exact Latest Default Line"/>
         </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,8 @@
                                  instance="org.lunakoly.quicklink.settings.QuickLinkSettingsConfigurable"
                                  id="org.lunakoly.quicklink.settings.QuickLinkSettingsConfigurable"
                                  displayName="Quick Link"/>
+        <notificationGroup id="QuickLink Notifications"
+                           displayType="BALLOON"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
> 🔥 Allow creating links to modified files
>
> In my experience, it's quite easy to quickly open it in the browser and fix the line manually compared to looking for another way to share the link.

> 🔥 Pick the closest reasonable commit if the current one was not pushed
>
> After this change there are now 3 actions:
> 
> - generating a link to the currently checked out commit
> - generating a link to the latest commit from the remote's default branch
> - generating a link to some parent commit that is definitely available at the remote
> 
> ...with the last one becoming the default assigned to `Cmd`+`Shift`+`L`.
> 
> The main use cases are generating a link to whatever I see in my IDE (so, close commits tend to also be acceptable since the code hasn't changed much) or showing something that is currently in the latest master. Also, I expect there to be not that many users relying on the plugin generating a link to exactly the current commit in scenarios when it has not been pushed, thought I don't really have any statistics. I assume no one has tried automating anything by calling the action or the default shortcut.