### PR TITLE
📃 Bump `pluginVersion` to `1.0.12`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.lunakoly.quicklink
 pluginName = Quick Link
 pluginRepositoryUrl = https://github.com/lunakoly/QuickLink
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.11
+pluginVersion = 1.0.12
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223


### PR DESCRIPTION
Maybe this can help get a green build on GHA:
https://youtrack.jetbrains.com/issue/QD-4936/Qodana-Gradle-plugin-fails-with-No-matching-toolchains-found-for-requested-specification-Gradle-8.0-RC.2#focus=Comments-27-7257990.0-0